### PR TITLE
drops docker-compose for docker built-in compose module

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 COMMAND="while [[ \"\$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601)\" != \"302\" ]]; do echo \"Waiting on Kibana to be ready...\"; sleep 1; done && curl -XPOST localhost:5601/api/saved_objects/index-pattern/artifact -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d '{\"attributes\":{\"timeFieldName\":\"timestamp\",\"title\":\"artifact*\"}}'"
+INTELOWL_TAG_VERSION=v4.0.1
 ELASTIC_VERSION=7.17.2 
 KIBANA_SERVER_NAME=host.docker.internal
 FIRST_ADMIN_USER=admin
@@ -8,3 +9,5 @@ VELO_PASSWORD=admin
 VELO_ROLE=administrator
 VELO_SERVER_URL=https://VelociraptorServer:8000/
 VELO_FRONTEND_HOSTNAME=VelociraptorServer
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-COMMAND="while [[ \"$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601)\" != \"302\" ]]; do echo \"Waiting on Kibana to be ready...\"; sleep 1; done && curl -XPOST localhost:5601/api/saved_objects/index-pattern/artifact -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d '{\"attributes\":{\"timeFieldName\":\"timestamp\",\"title\":\"artifact*\"}}'"
+COMMAND="while [[ \"\$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601)\" != \"302\" ]]; do echo \"Waiting on Kibana to be ready...\"; sleep 1; done && curl -XPOST localhost:5601/api/saved_objects/index-pattern/artifact -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d '{\"attributes\":{\"timeFieldName\":\"timestamp\",\"title\":\"artifact*\"}}'"
 ELASTIC_VERSION=7.17.2 
 KIBANA_SERVER_NAME=host.docker.internal
 FIRST_ADMIN_USER=admin

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To allow individuals to uickly spin up a local, integrated environment for analy
 ## Getting started
 ### Pre-reqs
 - Tested on Ubuntu 20.04, although 18.04 should work as well (or other distros)
-- Docker and docker-compose should be installed.
+- Docker should be installed.
 
 ### Clone
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,7 +209,7 @@ services:
       context: .
       dockerfile: docker/webApp/Dockerfile
     image: iriswebapp_app:latest
-    command: ['nohup', './iris-entrypoint.sh', 'iriswebapp']
+    command: /bin/bash -c "until pg_isready --username=$DB_USER --host=db; do sleep 1; done && nohup ./iris-entrypoint.sh iriswebapp"
     volumes:
       - iris-downloads:/home/iris/downloads
       - user_templates:/home/iris/user_templates

--- a/install_velocistack
+++ b/install_velocistack
@@ -8,10 +8,10 @@ sed -i "s/PRIMARY_IP/$PRIMARY_IP/" ./nginx/nginx.conf
 sed -i "s/PRIMARY_IP/$PRIMARY_IP/" ./velociraptor/add_viris_velo_module
 
 # Build images
-docker-compose --profile "elastic" --profile "intelowl" --profile "iris" build
+docker compose --profile "elastic" --profile "intelowl" --profile "iris" build
 
 # Start everything up
-docker-compose --profile "elastic" --profile "intelowl" --profile "iris" up -d
+docker compose --profile "elastic" --profile "intelowl" --profile "iris" up -d
 
 # Sleep for a minute
 echo "Sleeping for 60s to ensure services are online before proceeding..."

--- a/install_velocistack
+++ b/install_velocistack
@@ -5,7 +5,7 @@ PRIMARY_IP=$(hostname -I | awk '{print $1}')
 sed -i "s/PRIMARY_IP/$PRIMARY_IP/" ./nginx/nginx.conf
 
 # Substitute primary IP for IRIS server communication
-sed -i "s/PRIMARY_IP/$PRIMARY_IP/" ./velociraptor/add_viris_velo_module
+sed -i "s/PRIMARY_IP/$PRIMARY_IP/" ./velociraptor/add_iris_velo_module
 
 # Build images
 docker compose --profile "elastic" --profile "intelowl" --profile "iris" build


### PR DESCRIPTION
Sorry, but I was too lazy setting up individual PRs for all the mentioned issues below :p

This PR:
- fixes typo in ./install_velociraptor
- fixes syntax in ./.env - so the sub shell command does not get executed on COMMAND assignment
- drops requirement of docker-compose in favor of docker native compose module
- fixes missing env variables on start
- fixes iris crashing due to db not being up